### PR TITLE
[1/3] embed MCP server in fastAPI app

### DIFF
--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -215,6 +215,8 @@ def create_app(
     ui_mode: str = "auto",
     dev_url: Optional[str] = None,
     password: Optional[str] = None,
+    embed_mcp: bool = False,
+    mcp_path: str="/mcp"
 ) -> FastAPI:
     """
     Create a FastAPI app configured to serve the given workflow.
@@ -635,4 +637,13 @@ def create_app(
     except Exception as e:
         print(f"⚠ Failed to mount UI: {e}")
 
+    # Embed MCP if provided
+    if embed_mcp:
+        try:
+            from dr_agent.mcp_backend.main import mcp
+            mcp_app = mcp.http_app(path="/") # mount app
+            app.mount(mcp_path, mcp_app)
+            print(f"✓ MCP server embeded at {mcp_path}")
+        except Exception as e:
+            print(f"⚠ Failed to embed MCP: {e}")
     return app

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -236,7 +236,18 @@ def create_app(
     Returns:
         Configured FastAPI application
     """
-    app = FastAPI(title="DR-Agent Chat API")
+    # Create MCP app first if embedded
+    mcp_app = None
+    mcp_lifespan = None
+    if embed_mcp:
+        try:
+            from dr_agent.mcp_backend.main import mcp
+            mcp_app = mcp.http_app(path="/")
+            mcp_lifespan = mcp_app.lifespan
+        except Exception as e:
+            print(f"⚠ Failed to create MCP app: {e}")
+
+    app = FastAPI(title="DR-Agent Chat API", lifespan=mcp_lifespan)
 
     # Store workflow in app state
     app.state.workflow = workflow_instance
@@ -620,6 +631,11 @@ def create_app(
             "endpoints": ["/chat", "/chat/stream"],
         }
 
+    # Mount MCP before UI
+    if embed_mcp and mcp_app:
+        app.mount(mcp_path, mcp_app)
+        print(f"✓ MCP server embedded at {mcp_path}")
+
     # Mount UI files if available
     try:
         from dr_agent_ui.server import mount_ui
@@ -637,13 +653,4 @@ def create_app(
     except Exception as e:
         print(f"⚠ Failed to mount UI: {e}")
 
-    # Embed MCP if provided
-    if embed_mcp:
-        try:
-            from dr_agent.mcp_backend.main import mcp
-            mcp_app = mcp.http_app(path="/") # mount app
-            app.mount(mcp_path, mcp_app)
-            print(f"✓ MCP server embeded at {mcp_path}")
-        except Exception as e:
-            print(f"⚠ Failed to embed MCP: {e}")
     return app

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -1296,6 +1296,11 @@ class BaseWorkflow(ABC):
                 "-v",
                 help="Verbose output",
             ),
+            mcp_url: Optional[str] = typer.Option(
+                None,
+                "--mcp-url",
+                help="URL of the MCP server to embed",
+            ),
         ):
             """Start a live chat server for the workflow."""
             # Import web API dependencies here to avoid loading them when not needed
@@ -1338,6 +1343,12 @@ class BaseWorkflow(ABC):
                 logging.getLogger("LiteLLM").setLevel(logging.WARNING)
                 litellm.turn_off_message_logging = True
 
+            embed_mcp = mcp_url is None # embed MCP if not provided
+            
+            parsed_overrides["skip_mcp_check"] = True # skip MCP port check
+            if mcp_url:
+                parsed_overrides["mcp_url"] = mcp_url
+
             # Initialize workflow
             cls.__logger__.info("Initializing workflow...")
             workflow = cls(configuration=config_file, **parsed_overrides)
@@ -1345,8 +1356,13 @@ class BaseWorkflow(ABC):
 
             # Create FastAPI app
             fastapi_app = create_app(
-                workflow, ui_mode=ui_mode, password=password, dev_url=dev_url
+                workflow, ui_mode=ui_mode, password=password, dev_url=dev_url, embed_mcp=embed_mcp
             )
+            
+            if embed_mcp:
+                cls.__logger__.info(f"MCP server embeded")
+            else:
+                cls.__logger__.info("Using external MCP server: {mcp_url}")
 
             # Start server
             url = (

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -1347,7 +1347,7 @@ class BaseWorkflow(ABC):
             
             parsed_overrides["skip_mcp_check"] = True # skip MCP port check
             if embed_mcp:
-                parsed_overrides["mcp_url"] = f"http://localhost:{port}/mcp" # set endpoint to /mcp
+                parsed_overrides["mcp_url"] = f"http://localhost:{port}/mcp/" # set endpoint to /mcp
             else:
                 parsed_overrides["mcp_url"] = mcp_url
 

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -1346,7 +1346,9 @@ class BaseWorkflow(ABC):
             embed_mcp = mcp_url is None # embed MCP if not provided
             
             parsed_overrides["skip_mcp_check"] = True # skip MCP port check
-            if mcp_url:
+            if embed_mcp:
+                parsed_overrides["mcp_url"] = f"http://localhost:{port}/mcp" # set endpoint to /mcp
+            else:
                 parsed_overrides["mcp_url"] = mcp_url
 
             # Initialize workflow

--- a/workflows/auto_search_sft.py
+++ b/workflows/auto_search_sft.py
@@ -291,6 +291,8 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
         mcp_transport_type: str = "StreamableHttpTransport"
         mcp_executable: Optional[str] = None
         mcp_port: int = 8000
+        mcp_url: Optional[str] = None
+        skip_mcp_check: bool = False
 
         # Search configuration
         number_documents_to_search: int = 10
@@ -318,35 +320,49 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
         console.print(Panel.fit("🔍 Service Check", style="bold cyan"))
         console.print()
 
-        # Check MCP server
-        mcp_port = getattr(cfg, "mcp_port", 8000)
-        if not check_port(mcp_port):
-            console.print(
-                f"[yellow]⚠[/yellow]  MCP server is not running on port [bold]{mcp_port}[/bold]"
-            )
-            if Confirm.ask("Launch MCP server?"):
-                process = launch_mcp_server(mcp_port, self.logger)
-                if process:
-                    self._launched_processes.append(process)
-                    console.print(
-                        f"[green]✓[/green]  MCP server launched on port {mcp_port}"
-                    )
-                else:
-                    console.print(
-                        "[red]✗[/red]  Failed to start MCP server", style="bold red"
-                    )
-                    raise RuntimeError(
-                        "Failed to start MCP server. Please launch it manually."
-                    )
+        # Check whether to skip MCP check 
+        skip_mcp_check = getattr(cfg, "skip_mcp_check", False)
+
+        if skip_mcp_check:
+            mcp_url = getattr(cfg, "mcp_url", None)
+            if mcp_url:
+                console.print(
+                    f"[green]✓[/green]  Using external MCP server: [bold]{mcp_url}[/bold]"
+                )
             else:
-                console.print("[red]✗[/red]  MCP server is required", style="bold red")
-                raise RuntimeError(
-                    "MCP server is required. Please launch it manually or allow automatic launch."
+                console.print(
+                    "[green]✓[/green]  MCP server will be embedded in FastAPI app"
                 )
         else:
-            console.print(
-                f"[green]✓[/green]  MCP server is running on port [bold]{mcp_port}[/bold]"
-            )
+            # Check MCP server
+            mcp_port = getattr(cfg, "mcp_port", 8000)
+            if not check_port(mcp_port):
+                console.print(
+                    f"[yellow]⚠[/yellow]  MCP server is not running on port [bold]{mcp_port}[/bold]"
+                )
+                if Confirm.ask("Launch MCP server?"):
+                    process = launch_mcp_server(mcp_port, self.logger)
+                    if process:
+                        self._launched_processes.append(process)
+                        console.print(
+                            f"[green]✓[/green]  MCP server launched on port {mcp_port}"
+                        )
+                    else:
+                        console.print(
+                            "[red]✗[/red]  Failed to start MCP server", style="bold red"
+                        )
+                        raise RuntimeError(
+                            "Failed to start MCP server. Please launch it manually."
+                        )
+                else:
+                    console.print("[red]✗[/red]  MCP server is required", style="bold red")
+                    raise RuntimeError(
+                        "MCP server is required. Please launch it manually or allow automatic launch."
+                    )
+            else:
+                console.print(
+                    f"[green]✓[/green]  MCP server is running on port [bold]{mcp_port}[/bold]"
+                )
 
         # Check search agent vLLM server
         search_base_url = getattr(cfg, "search_agent_base_url", None)

--- a/workflows/auto_search_sft.py
+++ b/workflows/auto_search_sft.py
@@ -451,10 +451,10 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
         mcp_transport_type: Optional[str] = "StreamableHttpTransport",
         mcp_executable: Optional[str] = None,
         mcp_port: Optional[int] = 8000,
+        mcp_url: Optional[str] = None
     ) -> None:
         cfg = self.configuration
         assert cfg is not None
-        # print(cfg)
 
         # Allow configuration overrides for MCP settings
         if getattr(cfg, "mcp_transport_type", None):
@@ -463,6 +463,14 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
             mcp_executable = cfg.mcp_executable
         if getattr(cfg, "mcp_port", None) is not None:
             mcp_port = cfg.mcp_port
+        if getattr(cfg, "mcp_url", None):
+            mcp_url = cfg.mcp_url
+
+        mcp_kwargs = {"transport_type": mcp_transport_type, "mcp_executable": mcp_executable}
+        if mcp_url: # first check url
+            mcp_kwargs["mcp_url"] = mcp_url
+        else:
+            mcp_kwargs["mcp_port"] = mcp_port
 
         # Search and browse tools (MCP-backed) with unified tool parser
         if cfg.search_tool_name == "serper":
@@ -471,9 +479,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="snippet_search",  # <- to test this v20250824 model, we need to set the tool name in a hacky way.
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
 
             self.search_tool2 = SerperSearchTool(
@@ -481,9 +487,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="google_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.search_tool_name == "s2":
             self.search_tool = SemanticScholarSnippetSearchTool(
@@ -491,9 +495,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="snippet_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
 
             self.search_tool2 = SerperSearchTool(
@@ -501,9 +503,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="google_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.search_tool_name == "s2-only":
             self.search_tool = SemanticScholarSnippetSearchTool(
@@ -511,9 +511,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="snippet_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
 
             self.search_tool2 = SemanticScholarSnippetSearchTool(
@@ -521,9 +519,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="google_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         else:
             raise ValueError(f"Invalid search tool name: {cfg.search_tool_name}")
@@ -534,9 +530,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 max_pages_to_fetch=cfg.browse_max_pages_to_fetch,
                 timeout=cfg.browse_timeout,
                 name="browse_webpage",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.browse_tool_name == "crawl4ai":
             self.browse_tool = Crawl4AIBrowseTool(
@@ -544,21 +538,17 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 max_pages_to_fetch=cfg.browse_max_pages_to_fetch,
                 timeout=cfg.browse_timeout,
                 name="browse_webpage",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
                 context_chars=cfg.browse_context_char_length,
                 use_docker_version=cfg.crawl4ai_use_docker_version,
                 use_ai2_config=cfg.crawl4ai_use_ai2_config,
+                **mcp_kwargs,
             )
         elif cfg.browse_tool_name == "jina":
             self.browse_tool = JinaBrowseTool(
                 tool_parser=cfg.tool_parser,
                 timeout=cfg.browse_timeout,
                 name="browse_webpage",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.browse_tool_name is None:
             self.browse_tool = NoBrowseTool(


### PR DESCRIPTION
#1 
MCP is on the same port as fastAPI server at `/mcp`.
-  include --mcp-url flag for external MCP override
- skip MCP port check (only at serve mode)