### PR TITLE
[3/3] Multi-Workflow Serving

### DIFF
--- a/dr_agent/multi_serve.py
+++ b/dr_agent/multi_serve.py
@@ -44,7 +44,13 @@ def load_workflow(path: str) -> Type[BaseWorkflow]:
     raise ValueError(f"No BaseWorkflow subclass in {file_path}")
 
 
-def create_multi_app(workflows: List[BaseWorkflow], mcp_port: int = 8080) -> FastAPI:
+def create_multi_app(
+    workflows: List[BaseWorkflow],
+    workflow_names: List[str],
+    mcp_port: int = 8080,
+    ui_mode: str = "auto",
+    dev_url: Optional[str] = None,
+) -> FastAPI:
     """Create FastAPI app serving multiple workflows."""
     mcp_lifespan = None
     mcp_app = None
@@ -59,8 +65,7 @@ def create_multi_app(workflows: List[BaseWorkflow], mcp_port: int = 8080) -> Fas
     app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
     
     workflow_info = [] # list of workflows
-    for wf in workflows:
-        name = wf.get_workflow_name()
+    for wf, name in zip(workflows, workflow_names):
         app.include_router(create_workflow_router(wf), prefix=f"/agent/{name}", tags=[name])
         workflow_info.append({"name": name, "class": wf.__class__.__name__})
     
@@ -75,6 +80,19 @@ def create_multi_app(workflows: List[BaseWorkflow], mcp_port: int = 8080) -> Fas
     if mcp_app:
         app.mount("/mcp", mcp_app)
     
+    # Mount UI
+    try:
+        from dr_agent_ui.server import mount_ui
+        ui_mounted = mount_ui(app, ui_mode=ui_mode, dev_url=dev_url)
+        if ui_mounted:
+            print(f"UI mounted successfully in '{ui_mode}' mode")
+        else:
+            print(f"UI not mounted (mode: {ui_mode}). API endpoints are available.")
+    except ImportError:
+        print("dr_agent_ui not installed. Run: pip install dr-agent-ui")
+    except Exception as e:
+        print(f"Failed to mount UI: {e}")
+    
     return app
 
 
@@ -84,9 +102,12 @@ def serve(
     port: int = typer.Option(8080, "--port", "-p"),
     host: str = typer.Option("0.0.0.0", "--host"),
     config: Optional[str] = typer.Option(None, "--config", "-c", help="Config file (applies to all workflows)"),
+    ui_mode: str = typer.Option("auto", "--ui-mode", help="UI mode: auto, precompiled, dev, or proxy"),
+    dev_url: Optional[str] = typer.Option(None, "--dev-url", help="Dev server URL (for proxy mode)"),
 ):
     """Serve multiple workflows from one server."""
     workflows = []
+    workflow_names = []  # track names in order
     names = set()
     
     for spec in workflow_paths:
@@ -115,13 +136,13 @@ def serve(
             skip_mcp_check=True,
             mcp_url=f"http://localhost:{port}/mcp/",
         ))
+        workflow_names.append(name)
         print(f"✓ {cls.__name__} → /agent/{name}/ ({Path(config_path).name if config_path else 'default'})")
     
-    app = create_multi_app(workflows, mcp_port=port)
+    app = create_multi_app(workflows, workflow_names, mcp_port=port, ui_mode=ui_mode, dev_url=dev_url)
     
     print(f"\n{'='*50}\nServing at http://localhost:{port}")
-    for wf in workflows:
-        name = wf.get_workflow_name()
+    for name in workflow_names:
         print(f"   POST /agent/{name}/chat")
         print(f"   POST /agent/{name}/chat/stream")
         print(f"   POST /agent/{name}/chat/background")

--- a/dr_agent/multi_serve.py
+++ b/dr_agent/multi_serve.py
@@ -1,0 +1,140 @@
+"""Serve multiple workflows from one server CLI."""
+
+import hashlib
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import List, Optional, Type
+
+import typer
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .workflow import BaseWorkflow
+from .web_api.api import create_workflow_router
+
+app = typer.Typer()
+
+
+def load_workflow(path: str) -> Type[BaseWorkflow]:
+    """Load workflow class from file path. Supports path:ClassName syntax."""
+    file_path, class_name = (path.rsplit(":", 1) + [None])[:2]
+    file_path = Path(file_path).resolve()
+    
+    if not file_path.exists():
+        raise FileNotFoundError(f"Not found: {file_path}")
+    
+    # Use hash for unique module name
+    module_name = f"_wf_{hashlib.md5(str(file_path).encode()).hexdigest()[:8]}"
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    
+    if class_name:
+        return getattr(module, class_name)
+    
+    # Find first BaseWorkflow subclass
+    for _, obj in inspect.getmembers(module, inspect.isclass):
+        if issubclass(obj, BaseWorkflow) and obj is not BaseWorkflow:
+            return obj
+    
+    raise ValueError(f"No BaseWorkflow subclass in {file_path}")
+
+
+def create_multi_app(workflows: List[BaseWorkflow], mcp_port: int = 8080) -> FastAPI:
+    """Create FastAPI app serving multiple workflows."""
+    mcp_lifespan = None
+    mcp_app = None
+    try:
+        from dr_agent.mcp_backend.main import mcp
+        mcp_app = mcp.http_app(path="/")
+        mcp_lifespan = mcp_app.lifespan
+    except Exception as e:
+        print(f"⚠ MCP not available: {e}")
+    
+    app = FastAPI(title="DR-Agent Multi-Workflow API", lifespan=mcp_lifespan)
+    app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+    
+    workflow_info = [] # list of workflows
+    for wf in workflows:
+        name = wf.get_workflow_name()
+        app.include_router(create_workflow_router(wf), prefix=f"/agent/{name}", tags=[name])
+        workflow_info.append({"name": name, "class": wf.__class__.__name__})
+    
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "workflows": [w["name"] for w in workflow_info]}
+    
+    @app.get("/agent/")
+    async def list_agents():
+        return {"agents": workflow_info}
+    
+    if mcp_app:
+        app.mount("/mcp", mcp_app)
+    
+    return app
+
+
+@app.command()
+def serve(
+    workflow_paths: List[str] = typer.Argument(..., help="Workflow file paths (supports path:config.yaml:alias)"),
+    port: int = typer.Option(8080, "--port", "-p"),
+    host: str = typer.Option("0.0.0.0", "--host"),
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Config file (applies to all workflows)"),
+):
+    """Serve multiple workflows from one server."""
+    workflows = []
+    names = set()
+    
+    for spec in workflow_paths:
+        parts = spec.split(":")
+        if len(parts) == 1:
+            path, wf_config, alias = spec, None, None
+        elif len(parts) == 2: # path:config.yaml
+            path, wf_config, alias = parts[0], parts[1], None
+        elif len(parts) == 3: # alias
+            path = parts[0]
+            wf_config = parts[1] if parts[1] else None
+            alias = parts[2]
+        else:
+            raise typer.BadParameter(f"Invalid SPEC. Use path, path:config.yaml, path::alias, or path:config.yaml:alias")
+        
+        cls = load_workflow(path)
+        name = alias or cls.get_workflow_name()
+        if name in names:
+            raise typer.BadParameter(f"Duplicate workflow name: {name}")
+        names.add(name)
+        
+        config_path = wf_config or config or getattr(cls, '_default_configuration_path', None)
+        workflows.append(cls(
+            configuration=config_path,
+            skip_service_check=True,
+            skip_mcp_check=True,
+            mcp_url=f"http://localhost:{port}/mcp/",
+        ))
+        print(f"✓ {cls.__name__} → /agent/{name}/ ({Path(config_path).name if config_path else 'default'})")
+    
+    app = create_multi_app(workflows, mcp_port=port)
+    
+    print(f"\n{'='*50}\nServing at http://localhost:{port}")
+    for wf in workflows:
+        name = wf.get_workflow_name()
+        print(f"   POST /agent/{name}/chat")
+        print(f"   POST /agent/{name}/chat/stream")
+        print(f"   POST /agent/{name}/chat/background")
+        print(f"   WS   /agent/{name}/chat/background/ws")
+        print(f"   GET  /agent/{name}/jobs")
+        print(f"   POST /agent/{name}/jobs/{{job_id}}/cancel")
+    print(f"   GET  /health")
+    print(f"   GET  /agent/")
+    print(f"{'='*50}\n")
+    
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    app()
+

--- a/dr_agent/web_api/__init__.py
+++ b/dr_agent/web_api/__init__.py
@@ -5,7 +5,7 @@ This module provides a FastAPI-based web API that can serve any BaseWorkflow
 instance via Server-Sent Events (SSE) for live chat interactions.
 """
 
-from .api import create_app, SSECallback
+from .api import create_app, create_workflow_router, SSECallback
 
-__all__ = ["create_app", "SSECallback"]
+__all__ = ["create_app", "create_workflow_router", "SSECallback"]
 

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -11,7 +11,7 @@ import re
 import secrets
 from typing import Any, Dict, List, Optional
 
-from fastapi import Cookie, Depends, FastAPI, Form, HTTPException, Request, status
+from fastapi import Cookie, Depends, FastAPI, Form, HTTPException, Request, WebSocket, WebSocketDisconnect, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (
     HTMLResponse,
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from ..tool_interface.data_types import DocumentToolOutput, ToolOutput
 from ..workflow import BaseWorkflow
+from .jobs import JobManager
 
 
 class Message(BaseModel):
@@ -248,6 +249,9 @@ def create_app(
             print(f"⚠ Failed to create MCP app: {e}")
 
     app = FastAPI(title="DR-Agent Chat API", lifespan=mcp_lifespan)
+
+    # Initialize job manager
+    app.state.job_manager = JobManager()
 
     # Store workflow in app state
     app.state.workflow = workflow_instance
@@ -620,6 +624,97 @@ def create_app(
                 "X-Accel-Buffering": "no",  # Disable nginx buffering
             },
         )
+
+    @app.post("/chat/background")
+    async def chat_background(request: ChatRequest, _: bool = Depends(verify_auth)):
+        job_id = await app.state.job_manager.submit( # submit job
+            app.state.workflow,
+            problem=request.content or "",
+            dataset_name=request.dataset_name,
+            messages=[{"role": m.role, "content": m.content} for m in request.messages] if request.messages else None,
+            verbose=False,
+        )
+        return {"job_id": job_id, "status": "queued"}
+
+    @app.websocket("/chat/background/ws")
+    async def chat_background_ws(websocket: WebSocket):
+        """
+        WebSocket endpoint for background job execution
+        
+        Flow:
+         - Client connects
+         - Client sends chat request
+         - Server sends started acknowledgment
+         - Server sends completion status
+        """
+        await websocket.accept()
+        
+        try:
+            # Receive request from client
+            data = await websocket.receive_json()
+            content = data.get("content", "")
+            dataset_name = data.get("dataset_name", "long_form")
+            messages = data.get("messages")
+            
+            messages_dicts = None
+            if messages:
+                messages_dicts = [{"role": m["role"], "content": m["content"]} for m in messages]
+                if not content:
+                    for m in reversed(messages_dicts):
+                        if m["role"] == "user":
+                            content = m["content"]
+                            break
+            
+            # Submit job
+            job_id = await app.state.job_manager.submit(
+                app.state.workflow,
+                problem=content,
+                dataset_name=dataset_name,
+                messages=messages_dicts,
+                verbose=False,
+            )
+            
+            # Subscribe to updates
+            queue = app.state.job_manager.subscribe(job_id)
+            
+            # Promise 1: started acknowledgment
+            await websocket.send_json({"type": "started", "job_id": job_id})
+            
+            # Promise 2: wait for completion
+            while True:
+                update = await queue.get()
+                if update["status"] == "running":
+                    await websocket.send_json({"type": "running", "job_id": job_id})
+                elif update["status"] == "completed":
+                    # parse exact fields from raw results
+                    raw_result = update.get("result") or {}
+                    result = {
+                        "response": raw_result.get("final_response", ""),
+                        "metadata": {
+                            "total_tool_calls": raw_result.get("total_tool_calls", 0),
+                            "failed_tool_calls": raw_result.get("total_failed_tool_calls", 0),
+                            "browsed_links": raw_result.get("browsed_links", []),
+                            "searched_links": raw_result.get("searched_links", []),
+                        },
+                    }
+                    await websocket.send_json({"type": "completed", "result": result})
+                    break
+                elif update["status"] == "failed":
+                    await websocket.send_json({"type": "failed", "error": update.get("error")})
+                    break
+            
+            app.state.job_manager.unsubscribe(job_id, queue)
+            
+        except WebSocketDisconnect: # job continues even if client disconnects
+            pass
+
+    @app.get("/jobs/{job_id}")
+    async def get_job(job_id: str):
+        """Get job status"""
+        job = app.state.job_manager.get(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        return job
 
     @app.get("/health")
     async def health_check():

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -215,6 +215,8 @@ def create_app(
     ui_mode: str = "auto",
     dev_url: Optional[str] = None,
     password: Optional[str] = None,
+    embed_mcp: bool = False,
+    mcp_path: str="/mcp"
 ) -> FastAPI:
     """
     Create a FastAPI app configured to serve the given workflow.
@@ -635,4 +637,13 @@ def create_app(
     except Exception as e:
         print(f"⚠ Failed to mount UI: {e}")
 
+    # Embed MCP if provided
+    if embed_mcp:
+        try:
+            from dr_agent.mcp_backend.main import mcp
+            mcp_app = mcp.http_app(path="/") # mount app
+            app.mount(mcp_path, mcp_app)
+            print(f"✓ MCP server embeded at {mcp_path}")
+        except Exception as e:
+            print(f"⚠ Failed to embed MCP: {e}")
     return app

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -236,7 +236,18 @@ def create_app(
     Returns:
         Configured FastAPI application
     """
-    app = FastAPI(title="DR-Agent Chat API")
+    # Create MCP app first if embedded
+    mcp_app = None
+    mcp_lifespan = None
+    if embed_mcp:
+        try:
+            from dr_agent.mcp_backend.main import mcp
+            mcp_app = mcp.http_app(path="/")
+            mcp_lifespan = mcp_app.lifespan
+        except Exception as e:
+            print(f"⚠ Failed to create MCP app: {e}")
+
+    app = FastAPI(title="DR-Agent Chat API", lifespan=mcp_lifespan)
 
     # Store workflow in app state
     app.state.workflow = workflow_instance
@@ -620,6 +631,11 @@ def create_app(
             "endpoints": ["/chat", "/chat/stream"],
         }
 
+    # Mount MCP before UI
+    if embed_mcp and mcp_app:
+        app.mount(mcp_path, mcp_app)
+        print(f"✓ MCP server embedded at {mcp_path}")
+
     # Mount UI files if available
     try:
         from dr_agent_ui.server import mount_ui
@@ -637,13 +653,4 @@ def create_app(
     except Exception as e:
         print(f"⚠ Failed to mount UI: {e}")
 
-    # Embed MCP if provided
-    if embed_mcp:
-        try:
-            from dr_agent.mcp_backend.main import mcp
-            mcp_app = mcp.http_app(path="/") # mount app
-            app.mount(mcp_path, mcp_app)
-            print(f"✓ MCP server embeded at {mcp_path}")
-        except Exception as e:
-            print(f"⚠ Failed to embed MCP: {e}")
     return app

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -214,7 +214,9 @@ class SSECallback:
 def create_workflow_router(workflow_instance: BaseWorkflow) -> APIRouter:
     """Create an FastAPI router with chat endpoints for a workflow instance"""
     router = APIRouter()
-    job_manager = JobManager()
+    # workflow-specific database path for job persistence
+    workflow_name = workflow_instance.get_workflow_name()
+    job_manager = JobManager(db_path=f".cache/jobs_{workflow_name}.db")
     
     async def run_workflow_streaming(content: str, dataset_name: str, queue: asyncio.Queue, messages=None):
         callback = SSECallback(queue) # callback for SSE events

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -281,6 +281,9 @@ def create_workflow_router(workflow_instance: BaseWorkflow) -> APIRouter:
                 elif update["status"] == "failed":
                     await websocket.send_json({"type": "failed", "error": update.get("error")})
                     break
+                elif update["status"] == "cancelled":
+                    await websocket.send_json({"type": "cancelled", "job_id": job_id})
+                    break
             job_manager.unsubscribe(job_id, queue)
         except WebSocketDisconnect:
             pass
@@ -290,6 +293,12 @@ def create_workflow_router(workflow_instance: BaseWorkflow) -> APIRouter:
         if job := job_manager.get(job_id):
             return job
         raise HTTPException(status_code=404, detail="Job not found")
+
+    @router.post("/jobs/{job_id}/cancel")
+    async def cancel_job(job_id: str):
+        if await job_manager.cancel(job_id):
+            return {"status": "cancelled", "job_id": job_id}
+        raise HTTPException(status_code=404, detail="Job not found or already completed")
     
     return router
 
@@ -785,6 +794,9 @@ def create_app(
                 elif update["status"] == "failed":
                     await websocket.send_json({"type": "failed", "error": update.get("error")})
                     break
+                elif update["status"] == "cancelled":
+                    await websocket.send_json({"type": "cancelled", "job_id": job_id})
+                    break
             
             app.state.job_manager.unsubscribe(job_id, queue)
             
@@ -798,6 +810,13 @@ def create_app(
         if not job:
             raise HTTPException(status_code=404, detail="Job not found")
         return job
+
+    @app.post("/jobs/{job_id}/cancel")
+    async def cancel_job(job_id: str, _: bool = Depends(verify_auth)):
+        """Cancel a running job"""
+        if await app.state.job_manager.cancel(job_id):
+            return {"status": "cancelled", "job_id": job_id}
+        raise HTTPException(status_code=404, detail="Job not found or it might have already completed")
 
     @app.get("/health")
     async def health_check():

--- a/dr_agent/web_api/api.py
+++ b/dr_agent/web_api/api.py
@@ -11,7 +11,7 @@ import re
 import secrets
 from typing import Any, Dict, List, Optional
 
-from fastapi import Cookie, Depends, FastAPI, Form, HTTPException, Request, WebSocket, WebSocketDisconnect, status
+from fastapi import APIRouter, Cookie, Depends, FastAPI, Form, HTTPException, Request, WebSocket, WebSocketDisconnect, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (
     HTMLResponse,
@@ -209,6 +209,89 @@ class SSECallback:
             self.current_segment_text = ""
             self.is_answering = False
             self.thinking_segment_id += 1
+
+
+def create_workflow_router(workflow_instance: BaseWorkflow) -> APIRouter:
+    """Create an FastAPI router with chat endpoints for a workflow instance"""
+    router = APIRouter()
+    job_manager = JobManager()
+    
+    async def run_workflow_streaming(content: str, dataset_name: str, queue: asyncio.Queue, messages=None):
+        callback = SSECallback(queue) # callback for SSE events
+        await queue.put(f'data: {{"type": "started"}}\n\n')
+        result = await workflow_instance(problem=content, dataset_name=dataset_name, messages=messages, verbose=False, step_callback=callback)
+        if final := result.get("final_response"): # finial response
+            await queue.put(f'data: {json.dumps({"type": "answer", "content": final, "is_final": True})}\n\n')
+        await queue.put(f'data: {json.dumps({"type": "done", "metadata": {"total_tool_calls": result.get("total_tool_calls", 0)}})}\n\n')
+        await queue.put(None)
+    
+    @router.post("/chat")
+    async def chat(request: ChatRequest):
+        msgs = [{"role": m.role, "content": m.content} for m in request.messages] if request.messages else None
+        content = request.content or (msgs[-1]["content"] if msgs else "")
+        result = await workflow_instance(problem=content, dataset_name=request.dataset_name, messages=msgs, verbose=False)
+        return {"response": result.get("final_response", ""), "metadata": {"total_tool_calls": result.get("total_tool_calls", 0)}}
+    
+    @router.post("/chat/stream")
+    async def chat_stream(request: ChatRequest):
+        queue = asyncio.Queue()
+        msgs = [{"role": m.role, "content": m.content} for m in request.messages] if request.messages else None
+        content = request.content or (msgs[-1]["content"] if msgs else "")
+        
+        async def gen():
+            task = asyncio.create_task(run_workflow_streaming(content, request.dataset_name, queue, msgs))
+            try:
+                while (event := await queue.get()) is not None:
+                    yield event
+            except asyncio.CancelledError:
+                task.cancel()
+                raise
+        return StreamingResponse(gen(), media_type="text/event-stream", headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
+    
+    @router.post("/chat/background")
+    async def chat_background(request: ChatRequest): # background job
+        job_id = await job_manager.submit(workflow_instance, problem=request.content or "", dataset_name=request.dataset_name, messages=[{"role": m.role, "content": m.content} for m in request.messages] if request.messages else None, verbose=False)
+        return {"job_id": job_id, "status": "queued"}
+    
+    @router.websocket("/chat/background/ws")
+    async def chat_background_ws(websocket: WebSocket):
+        """WebSocket endpoint for background job execution with live updates"""
+        await websocket.accept()
+        try:
+            data = await websocket.receive_json()
+            content = data.get("content", "")
+            dataset_name = data.get("dataset_name", "long_form")
+            messages = data.get("messages")
+            msgs = [{"role": m["role"], "content": m["content"]} for m in messages] if messages else None
+            if not content and msgs:
+                content = next((m["content"] for m in reversed(msgs) if m["role"] == "user"), "")
+            
+            job_id = await job_manager.submit(workflow_instance, problem=content, dataset_name=dataset_name, messages=msgs, verbose=False)
+            queue = job_manager.subscribe(job_id)
+            await websocket.send_json({"type": "started", "job_id": job_id})
+            
+            while True:
+                update = await queue.get()
+                if update["status"] == "running":
+                    await websocket.send_json({"type": "running", "job_id": job_id})
+                elif update["status"] == "completed":
+                    raw = update.get("result") or {}
+                    await websocket.send_json({"type": "completed", "result": {"response": raw.get("final_response", ""), "metadata": {"total_tool_calls": raw.get("total_tool_calls", 0)}}})
+                    break
+                elif update["status"] == "failed":
+                    await websocket.send_json({"type": "failed", "error": update.get("error")})
+                    break
+            job_manager.unsubscribe(job_id, queue)
+        except WebSocketDisconnect:
+            pass
+    
+    @router.get("/jobs/{job_id}")
+    async def get_job(job_id: str):
+        if job := job_manager.get(job_id):
+            return job
+        raise HTTPException(status_code=404, detail="Job not found")
+    
+    return router
 
 
 def create_app(

--- a/dr_agent/web_api/jobs.py
+++ b/dr_agent/web_api/jobs.py
@@ -1,45 +1,168 @@
-"""Background job execution."""
+"""Background job execution with persistence."""
 import asyncio
+import json
+import sqlite3
 import uuid
+from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Callable, Coroutine
+from pathlib import Path
+from typing import Any, Callable, Coroutine, Optional
 
 
 class JobManager:
-    def __init__(self):
-        self._jobs = {}
+    def __init__(self, db_path: Optional[str] = None, cache_size: int = 100):
+        self._jobs = OrderedDict()  # LRU cache
         self._tasks = {}
-        self._subscribers = {} # subscribers for each job
+        self._subscribers = {}  # subscribers for each job
+        self._cache_size = cache_size
+        self._db_path = Path(db_path) if db_path else Path(".cache/jobs.db")
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+        self._mark_orphaned_jobs()
+        self._load_persisted_jobs()
+    
+    def _init_db(self):
+        """Initialize SQLite database with single connection and WAL mode."""
+        self._conn = sqlite3.connect(
+            self._db_path,
+            check_same_thread=False,
+            isolation_level=None
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL") # write-ahead logging mode
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS jobs (
+                job_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                result TEXT,
+                error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_updated_at ON jobs(updated_at DESC)")
+    
+    def _mark_orphaned_jobs(self):
+        """Mark queued/running jobs as failed on startup."""
+        self._conn.execute("""
+            UPDATE jobs
+            SET status = 'failed', error = 'server_restart', updated_at = ?
+            WHERE status IN ('queued', 'running')
+        """, (datetime.utcnow().isoformat(),))
+    
+    def _load_persisted_jobs(self):
+        """Load persisted jobs from database into cache."""
+        cursor = self._conn.execute("""
+            SELECT job_id, status, result, error, created_at, updated_at
+            FROM jobs
+            WHERE status IN ('completed', 'failed', 'cancelled')
+            ORDER BY updated_at DESC
+            LIMIT ?
+        """, (self._cache_size,))
+        
+        for row in cursor:
+            job_id, status, result_json, error, created_at, updated_at = row
+            self._jobs[job_id] = {
+                "status": status,
+                "result": json.loads(result_json) if result_json else None,
+                "error": error,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+            self._jobs.move_to_end(job_id)
+    
+    def _serialize_result(self, result: Any) -> Optional[str]:
+        """Serialize result to JSON for job persistence."""
+        if result is None:
+            return None
+        
+        # Convert Pydantic models to dict
+        if hasattr(result, "model_dump"):
+            result = result.model_dump()
+        elif hasattr(result, "dict"):
+            result = result.dict()
+        
+        try:
+            return json.dumps(result, default=str)
+        except (TypeError, ValueError):
+            return json.dumps({"__error__": "Serialization failed", "__repr__": str(result)})
+    
+    def _persist_job(self, job_id: str, job: dict):
+        """Persist job to SQLite using shared connection."""
+        result_json = self._serialize_result(job.get("result"))
+        self._conn.execute("""
+            INSERT OR REPLACE INTO jobs (job_id, status, result, error, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """, (
+            job_id,
+            job["status"],
+            result_json,
+            job.get("error"),
+            job["created_at"],
+            job.get("updated_at", job["created_at"]),
+        ))
+    
+    def _evict_lru(self):
+        """Evict least recently used job from cache if over limit."""
+        if len(self._jobs) >= self._cache_size:
+            # Remove oldest (first) item
+            self._jobs.popitem(last=False)
 
     async def submit(self, fn, **kwargs) -> str:
         job_id = str(uuid.uuid4())
-        self._jobs[job_id] = {
+        now = datetime.utcnow().isoformat()
+        job = {
             "status": "queued",
             "result": None,
             "error": None,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": now,
+            "updated_at": now,
         }
-        self._subscribers[job_id] = [] # initially no subscribers
+        self._add_to_cache(job_id, job)
+        self._subscribers[job_id] = []  # initially no subscribers
 
         async def run():
-            self._jobs[job_id]["status"] = "running"
+            self._update_job(job_id, "running")
             await self._notify(job_id, "running")
             try:
                 result = await fn(**kwargs)
-                self._jobs[job_id].update(status="completed", result=result)
+                self._update_job(job_id, "completed", result=result)
                 await self._notify(job_id, "completed", result=result)
             except asyncio.CancelledError:
-                self._jobs[job_id].update(status="cancelled")
+                self._update_job(job_id, "cancelled")
                 await self._notify(job_id, "cancelled")
                 raise
             except Exception as e:
-                self._jobs[job_id].update(status="failed", error=str(e))
+                self._update_job(job_id, "failed", error=str(e))
                 await self._notify(job_id, "failed", error=str(e))
             finally:
                 self._tasks.pop(job_id, None)
 
         self._tasks[job_id] = asyncio.create_task(run())
         return job_id
+    
+    def _add_to_cache(self, job_id: str, job: dict):
+        """Add job to LRU cache."""
+        self._evict_lru()
+        self._jobs[job_id] = job
+        # move to end
+        self._jobs.move_to_end(job_id) # recent
+    
+    def _update_job(self, job_id: str, status: str, result: Any = None, error: str = None):
+        """Update job status and persist on every state change."""
+        if job_id not in self._jobs:
+            return
+        
+        job = self._jobs[job_id]
+        job["status"] = status
+        job["updated_at"] = datetime.utcnow().isoformat()
+        if result is not None:
+            job["result"] = result
+        if error is not None:
+            job["error"] = error
+        
+        self._jobs.move_to_end(job_id)
+        self._persist_job(job_id, job)
 
     async def cancel(self, job_id: str) -> bool:
         """Cancel a running job. Returns True if cancelled, else False."""
@@ -72,6 +195,37 @@ class JobManager:
             except ValueError:
                 pass
 
-    def get(self, job_id):
-        return self._jobs.get(job_id)
+    def get(self, job_id: str) -> Optional[dict]:
+        """Get job by ID. First check cache, then database."""
+        # Check cache
+        if job_id in self._jobs:
+            self._jobs.move_to_end(job_id)  # update LRU
+            return self._jobs[job_id]
+        
+        cursor = self._conn.execute("""
+            SELECT status, result, error, created_at, updated_at
+            FROM jobs
+            WHERE job_id = ?
+        """, (job_id,))
+        row = cursor.fetchone()
+        
+        if row:
+            status, result_json, error, created_at, updated_at = row
+            job = {
+                "status": status,
+                "result": json.loads(result_json) if result_json else None,
+                "error": error,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+            # Add to cache
+            self._add_to_cache(job_id, job)
+            return job
+        
+        return None
+    
+    def close(self):
+        """Close database connection."""
+        if hasattr(self, "_conn"):
+            self._conn.close()
 

--- a/dr_agent/web_api/jobs.py
+++ b/dr_agent/web_api/jobs.py
@@ -119,6 +119,7 @@ class JobManager:
             "updated_at": now,
         }
         self._add_to_cache(job_id, job)
+        self._persist_job(job_id, job)
         self._subscribers[job_id] = []  # initially no subscribers
 
         async def run():

--- a/dr_agent/web_api/jobs.py
+++ b/dr_agent/web_api/jobs.py
@@ -1,0 +1,63 @@
+"""Background job execution."""
+import asyncio
+import uuid
+from datetime import datetime
+from typing import Any, Callable, Coroutine
+
+
+class JobManager:
+    def __init__(self):
+        self._jobs = {}
+        self._tasks = {}
+        self._subscribers = {} # subscribers for each job
+
+    async def submit(self, fn, **kwargs) -> str:
+        job_id = str(uuid.uuid4())
+        self._jobs[job_id] = {
+            "status": "queued",
+            "result": None,
+            "error": None,
+            "created_at": datetime.utcnow().isoformat(),
+        }
+        self._subscribers[job_id] = [] # initially no subscribers
+
+        async def run():
+            self._jobs[job_id]["status"] = "running"
+            await self._notify(job_id, "running")
+            try:
+                result = await fn(**kwargs)
+                self._jobs[job_id].update(status="completed", result=result)
+                await self._notify(job_id, "completed", result=result)
+            except Exception as e:
+                self._jobs[job_id].update(status="failed", error=str(e))
+                await self._notify(job_id, "failed", error=str(e))
+
+        self._tasks[job_id] = asyncio.create_task(run())
+        return job_id
+
+    async def _notify(self, job_id, status, **data):
+        """Push status change to all subscribers."""
+        for queue in self._subscribers.get(job_id, []):
+            await queue.put({"status": status, **data})
+
+    def subscribe(self, job_id):
+        """Be added to subscribers list."""
+        queue = asyncio.Queue()
+        self._subscribers.setdefault(job_id, []).append(queue)
+    
+        job = self._jobs.get(job_id)
+        if job and job["status"] != "queued": # push current status if job started
+            queue.put_nowait({"status": job["status"], "result": job.get("result"), "error": job.get("error")})
+        return queue
+
+    def unsubscribe(self, job_id, queue):
+        """Remove from subscribers list."""
+        if job_id in self._subscribers:
+            try:
+                self._subscribers[job_id].remove(queue)
+            except ValueError:
+                pass
+
+    def get(self, job_id):
+        return self._jobs.get(job_id)
+

--- a/dr_agent/web_api/jobs.py
+++ b/dr_agent/web_api/jobs.py
@@ -28,12 +28,26 @@ class JobManager:
                 result = await fn(**kwargs)
                 self._jobs[job_id].update(status="completed", result=result)
                 await self._notify(job_id, "completed", result=result)
+            except asyncio.CancelledError:
+                self._jobs[job_id].update(status="cancelled")
+                await self._notify(job_id, "cancelled")
+                raise
             except Exception as e:
                 self._jobs[job_id].update(status="failed", error=str(e))
                 await self._notify(job_id, "failed", error=str(e))
+            finally:
+                self._tasks.pop(job_id, None)
 
         self._tasks[job_id] = asyncio.create_task(run())
         return job_id
+
+    async def cancel(self, job_id: str) -> bool:
+        """Cancel a running job. Returns True if cancelled, else False."""
+        task = self._tasks.get(job_id)
+        if task and not task.done():
+            task.cancel()
+            return True
+        return False
 
     async def _notify(self, job_id, status, **data):
         """Push status change to all subscribers."""

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -1296,6 +1296,11 @@ class BaseWorkflow(ABC):
                 "-v",
                 help="Verbose output",
             ),
+            mcp_url: Optional[str] = typer.Option(
+                None,
+                "--mcp-url",
+                help="URL of the MCP server to embed",
+            ),
         ):
             """Start a live chat server for the workflow."""
             # Import web API dependencies here to avoid loading them when not needed
@@ -1338,6 +1343,12 @@ class BaseWorkflow(ABC):
                 logging.getLogger("LiteLLM").setLevel(logging.WARNING)
                 litellm.turn_off_message_logging = True
 
+            embed_mcp = mcp_url is None # embed MCP if not provided
+            
+            parsed_overrides["skip_mcp_check"] = True # skip MCP port check
+            if mcp_url:
+                parsed_overrides["mcp_url"] = mcp_url
+
             # Initialize workflow
             cls.__logger__.info("Initializing workflow...")
             workflow = cls(configuration=config_file, **parsed_overrides)
@@ -1345,8 +1356,13 @@ class BaseWorkflow(ABC):
 
             # Create FastAPI app
             fastapi_app = create_app(
-                workflow, ui_mode=ui_mode, password=password, dev_url=dev_url
+                workflow, ui_mode=ui_mode, password=password, dev_url=dev_url, embed_mcp=embed_mcp
             )
+            
+            if embed_mcp:
+                cls.__logger__.info(f"MCP server embeded")
+            else:
+                cls.__logger__.info("Using external MCP server: {mcp_url}")
 
             # Start server
             url = (

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -1347,7 +1347,7 @@ class BaseWorkflow(ABC):
             
             parsed_overrides["skip_mcp_check"] = True # skip MCP port check
             if embed_mcp:
-                parsed_overrides["mcp_url"] = f"http://localhost:{port}/mcp" # set endpoint to /mcp
+                parsed_overrides["mcp_url"] = f"http://localhost:{port}/mcp/" # set endpoint to /mcp
             else:
                 parsed_overrides["mcp_url"] = mcp_url
 

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -1346,7 +1346,9 @@ class BaseWorkflow(ABC):
             embed_mcp = mcp_url is None # embed MCP if not provided
             
             parsed_overrides["skip_mcp_check"] = True # skip MCP port check
-            if mcp_url:
+            if embed_mcp:
+                parsed_overrides["mcp_url"] = f"http://localhost:{port}/mcp" # set endpoint to /mcp
+            else:
                 parsed_overrides["mcp_url"] = mcp_url
 
             # Initialize workflow

--- a/dr_agent/workflow.py
+++ b/dr_agent/workflow.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 import subprocess
+import re
 import weakref
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -160,6 +161,16 @@ class BaseWorkflow(ABC):
 
     __logger__ = logging.getLogger(__name__)
     __logger__.setLevel(logging.INFO)
+
+    @classmethod
+    def get_workflow_name(cls) -> str:
+        """Make workflow name URL-safe from class name"""
+        name = cls.__name__
+        for s in ('Workflow', 'Agent', 'Pipeline'): # check suffixes
+            if name.endswith(s):
+                name = name[:-len(s)]
+                break
+        return re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower() # replace with underscore
 
     @property
     @abstractmethod

--- a/workflows/auto_search_sft.py
+++ b/workflows/auto_search_sft.py
@@ -189,7 +189,13 @@ class AnswerAgent(BaseAgent):
         elif dataset_name in ["healthbench", "deep_research_bench", "researchqa"]:
             instruction_field_name = "short_form"
         else:
-            raise ValueError(f"Invalid dataset name: {dataset_name}")
+            # Fallback: check if dataset_name contains hints
+            if "short_form" in str(dataset_name):
+                instruction_field_name = "exact_answer"
+            elif "long_form" in str(dataset_name):
+                instruction_field_name = "long_form"
+            else:
+                raise ValueError(f"Invalid dataset name: {dataset_name}")
 
         return [
             {

--- a/workflows/auto_search_sft.py
+++ b/workflows/auto_search_sft.py
@@ -291,6 +291,8 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
         mcp_transport_type: str = "StreamableHttpTransport"
         mcp_executable: Optional[str] = None
         mcp_port: int = 8000
+        mcp_url: Optional[str] = None
+        skip_mcp_check: bool = False
 
         # Search configuration
         number_documents_to_search: int = 10
@@ -318,35 +320,49 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
         console.print(Panel.fit("🔍 Service Check", style="bold cyan"))
         console.print()
 
-        # Check MCP server
-        mcp_port = getattr(cfg, "mcp_port", 8000)
-        if not check_port(mcp_port):
-            console.print(
-                f"[yellow]⚠[/yellow]  MCP server is not running on port [bold]{mcp_port}[/bold]"
-            )
-            if Confirm.ask("Launch MCP server?"):
-                process = launch_mcp_server(mcp_port, self.logger)
-                if process:
-                    self._launched_processes.append(process)
-                    console.print(
-                        f"[green]✓[/green]  MCP server launched on port {mcp_port}"
-                    )
-                else:
-                    console.print(
-                        "[red]✗[/red]  Failed to start MCP server", style="bold red"
-                    )
-                    raise RuntimeError(
-                        "Failed to start MCP server. Please launch it manually."
-                    )
+        # Check whether to skip MCP check 
+        skip_mcp_check = getattr(cfg, "skip_mcp_check", False)
+
+        if skip_mcp_check:
+            mcp_url = getattr(cfg, "mcp_url", None)
+            if mcp_url:
+                console.print(
+                    f"[green]✓[/green]  Using external MCP server: [bold]{mcp_url}[/bold]"
+                )
             else:
-                console.print("[red]✗[/red]  MCP server is required", style="bold red")
-                raise RuntimeError(
-                    "MCP server is required. Please launch it manually or allow automatic launch."
+                console.print(
+                    "[green]✓[/green]  MCP server will be embedded in FastAPI app"
                 )
         else:
-            console.print(
-                f"[green]✓[/green]  MCP server is running on port [bold]{mcp_port}[/bold]"
-            )
+            # Check MCP server
+            mcp_port = getattr(cfg, "mcp_port", 8000)
+            if not check_port(mcp_port):
+                console.print(
+                    f"[yellow]⚠[/yellow]  MCP server is not running on port [bold]{mcp_port}[/bold]"
+                )
+                if Confirm.ask("Launch MCP server?"):
+                    process = launch_mcp_server(mcp_port, self.logger)
+                    if process:
+                        self._launched_processes.append(process)
+                        console.print(
+                            f"[green]✓[/green]  MCP server launched on port {mcp_port}"
+                        )
+                    else:
+                        console.print(
+                            "[red]✗[/red]  Failed to start MCP server", style="bold red"
+                        )
+                        raise RuntimeError(
+                            "Failed to start MCP server. Please launch it manually."
+                        )
+                else:
+                    console.print("[red]✗[/red]  MCP server is required", style="bold red")
+                    raise RuntimeError(
+                        "MCP server is required. Please launch it manually or allow automatic launch."
+                    )
+            else:
+                console.print(
+                    f"[green]✓[/green]  MCP server is running on port [bold]{mcp_port}[/bold]"
+                )
 
         # Check search agent vLLM server
         search_base_url = getattr(cfg, "search_agent_base_url", None)

--- a/workflows/auto_search_sft.py
+++ b/workflows/auto_search_sft.py
@@ -451,10 +451,10 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
         mcp_transport_type: Optional[str] = "StreamableHttpTransport",
         mcp_executable: Optional[str] = None,
         mcp_port: Optional[int] = 8000,
+        mcp_url: Optional[str] = None
     ) -> None:
         cfg = self.configuration
         assert cfg is not None
-        # print(cfg)
 
         # Allow configuration overrides for MCP settings
         if getattr(cfg, "mcp_transport_type", None):
@@ -463,6 +463,14 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
             mcp_executable = cfg.mcp_executable
         if getattr(cfg, "mcp_port", None) is not None:
             mcp_port = cfg.mcp_port
+        if getattr(cfg, "mcp_url", None):
+            mcp_url = cfg.mcp_url
+
+        mcp_kwargs = {"transport_type": mcp_transport_type, "mcp_executable": mcp_executable}
+        if mcp_url: # first check url
+            mcp_kwargs["mcp_url"] = mcp_url
+        else:
+            mcp_kwargs["mcp_port"] = mcp_port
 
         # Search and browse tools (MCP-backed) with unified tool parser
         if cfg.search_tool_name == "serper":
@@ -471,9 +479,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="snippet_search",  # <- to test this v20250824 model, we need to set the tool name in a hacky way.
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
 
             self.search_tool2 = SerperSearchTool(
@@ -481,9 +487,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="google_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.search_tool_name == "s2":
             self.search_tool = SemanticScholarSnippetSearchTool(
@@ -491,9 +495,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="snippet_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
 
             self.search_tool2 = SerperSearchTool(
@@ -501,9 +503,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="google_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.search_tool_name == "s2-only":
             self.search_tool = SemanticScholarSnippetSearchTool(
@@ -511,9 +511,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="snippet_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
 
             self.search_tool2 = SemanticScholarSnippetSearchTool(
@@ -521,9 +519,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 number_documents_to_search=cfg.number_documents_to_search,
                 timeout=cfg.search_timeout,
                 name="google_search",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         else:
             raise ValueError(f"Invalid search tool name: {cfg.search_tool_name}")
@@ -534,9 +530,7 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 max_pages_to_fetch=cfg.browse_max_pages_to_fetch,
                 timeout=cfg.browse_timeout,
                 name="browse_webpage",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.browse_tool_name == "crawl4ai":
             self.browse_tool = Crawl4AIBrowseTool(
@@ -544,21 +538,17 @@ class AutoReasonSearchWorkflow(BaseWorkflow):
                 max_pages_to_fetch=cfg.browse_max_pages_to_fetch,
                 timeout=cfg.browse_timeout,
                 name="browse_webpage",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
                 context_chars=cfg.browse_context_char_length,
                 use_docker_version=cfg.crawl4ai_use_docker_version,
                 use_ai2_config=cfg.crawl4ai_use_ai2_config,
+                **mcp_kwargs,
             )
         elif cfg.browse_tool_name == "jina":
             self.browse_tool = JinaBrowseTool(
                 tool_parser=cfg.tool_parser,
                 timeout=cfg.browse_timeout,
                 name="browse_webpage",
-                transport_type=mcp_transport_type,
-                mcp_executable=mcp_executable,
-                mcp_port=mcp_port,
+                **mcp_kwargs,
             )
         elif cfg.browse_tool_name is None:
             self.browse_tool = NoBrowseTool(


### PR DESCRIPTION
#2 
Usage
`python -m dr_agent.multi_serve \
  workflows/auto_search_sft.py \
  workflows/other_agent.py \
  --port 8080`

Serve multiple workflow agents from a single server

Endpoints:
- POST /agent/{name}/chat
- POST /agent/{name}/chat/stream (SSE streaming)
- POST /agent/{name}/chat/background
- POST /agent/{name}/chat/background/ws (websockets)
- GET  /health 

where `name` is derived from class name (i.e. AutoReasonSearchWorkflow -> auto_reason_search)